### PR TITLE
 [10.x] Uses PHP Native Type Declarations

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - name: Checkout repository
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v4
 
   #     - name: Setup MySQL 
   #       uses: mirromutth/mysql-action@v1.1
@@ -60,7 +60,7 @@ jobs:
   #   needs: php_unit_test
   #   steps:
   #     - name: Checkout repository
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v4
 
   #     - name: Setup PHP
   #       uses: shivammathur/setup-php@v2
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
  
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ v2-redis.env
 contents/DigiCertGlobalRootG2.crt.pem
 contents/LINEBot(Main).postman_collection.json
 /contents/tools/rector/vendor
+/contents/.phpunit.cache

--- a/contents/app/Console/Kernel.php
+++ b/contents/app/Console/Kernel.php
@@ -23,7 +23,7 @@ class Kernel extends ConsoleKernel
      * @param \Illuminate\Console\Scheduling\Schedule $schedule
      * @return void
      */
-    protected function schedule(Schedule $schedule)
+    protected function schedule(Schedule $schedule): void
     {
         // $schedule->command('users:sendreminder')->dailyAt('22:10');
         // $schedule->command('users:sendreminder')->everyMinute();
@@ -48,7 +48,7 @@ class Kernel extends ConsoleKernel
      *
      * @return void
      */
-    protected function commands()
+    protected function commands(): void
     {
         $this->load(__DIR__ . '/Commands');
 

--- a/contents/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/contents/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -6,6 +6,7 @@ use App\Providers\RouteServiceProvider;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
 
 class RedirectIfAuthenticated
 {
@@ -17,7 +18,7 @@ class RedirectIfAuthenticated
      * @param string|null ...$guards
      * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
      */
-    public function handle(Request $request, Closure $next, ...$guards)
+    public function handle(Request $request, Closure $next, string ...$guards): Response
     {
         $guards = empty($guards) ? [null] : $guards;
 

--- a/contents/app/Http/Middleware/TrustHosts.php
+++ b/contents/app/Http/Middleware/TrustHosts.php
@@ -11,7 +11,7 @@ class TrustHosts extends Middleware
      *
      * @return array<int, string|null>
      */
-    public function hosts()
+    public function hosts(): array
     {
         return [
             $this->allSubdomainsOfApplicationUrl(),

--- a/contents/app/Providers/AppServiceProvider.php
+++ b/contents/app/Providers/AppServiceProvider.php
@@ -13,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
@@ -23,7 +23,7 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->environment('production')) {
             URL::forceScheme('https');

--- a/contents/app/Providers/BroadcastServiceProvider.php
+++ b/contents/app/Providers/BroadcastServiceProvider.php
@@ -12,7 +12,7 @@ class BroadcastServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         Broadcast::routes();
 

--- a/contents/app/Providers/EventServiceProvider.php
+++ b/contents/app/Providers/EventServiceProvider.php
@@ -25,8 +25,13 @@ class EventServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
+    }
+
+    public function shouldDiscoverEvents(): bool
+    {
+        return false;
     }
 }

--- a/contents/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/contents/database/migrations/2014_10_12_000000_create_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
             $table->id();
@@ -40,7 +40,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('users');
     }

--- a/contents/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/contents/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
@@ -29,7 +29,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('failed_jobs');
     }

--- a/contents/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/contents/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
@@ -29,7 +29,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('personal_access_tokens');
     }

--- a/contents/database/seeders/DatabaseSeeder.php
+++ b/contents/database/seeders/DatabaseSeeder.php
@@ -11,7 +11,7 @@ class DatabaseSeeder extends Seeder
      *
      * @return void
      */
-    public function run()
+    public function run(): void
     {
         $this->call([
             AdminsSeeder::class,

--- a/contents/tests/CreatesApplication.php
+++ b/contents/tests/CreatesApplication.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
 
 trait CreatesApplication
 {
@@ -11,7 +12,7 @@ trait CreatesApplication
      *
      * @return \Illuminate\Foundation\Application
      */
-    public function createApplication()
+    public function createApplication(): Application
     {
         $app = require __DIR__ . '/../bootstrap/app.php';
 


### PR DESCRIPTION
### [[36] [Compare Code] Change github actions checkout v2 to v4 in actions.yml file](https://github.com/dtvn-training/linebot/commit/d4e5ec5895877785c0f1e93f7e37129b2ceeea31)
#### .github/workflows/tests.yml
1. actions/checkout@v1, actions/checkout@v2, actions/checkout@v3, and actions/checkout@v4 are different versions of the `checkout` action in GitHub Actions, used to copy source code from the repository into the working environment. 
2. The difference between `uses: actions/checkout@v3` and `uses: actions/checkout@v4` can be the performance improvements, bug fixes, and new features that each version brings, but specifically This needs to be seen from the documentation or updates from GitHub.
=> Not required, however should change . 
=> In the linebot/.github/workflows/actions.yml file, convert actions/checkout@v2 to actions/checkout@v4 to get the new features of actions/checkout@v4"
### [[36] [Compare Code] add .phpunit.cache to .gitignore file](https://github.com/dtvn-training/linebot/commit/220379aa5fb25bf52a8f546affde0e37e5482dd1)
#### .gitignore
1. In laravel 10, when running the php artisan test command, it generates an additional .phpunit.cache folder, adding .gitignore so that github will ignore it without tracking its changes.
### [[36] [Compare Code] Uses PHP Native Type Declarations](https://github.com/dtvn-training/linebot/commit/3a5267666175b07f882e7eb9d89241df6e9fe328)
1. Adds basic typing around method's arguments and return types
=> Typing in php and laravel helps increase clarity, makes it easy to recognize what type of value the function returns, and is easy to maintain. If the return value and the typing around method have different data types, a warning may be generated (does not generate an error, making it easy for the developer to fix the error).