### PR TITLE
[36] [10.x] Minor skeleton slimming

### DIFF
--- a/contents/app/Exceptions/Handler.php
+++ b/contents/app/Exceptions/Handler.php
@@ -34,7 +34,7 @@ class Handler extends ExceptionHandler
      *
      * @return void
      */
-    public function register()
+    public function register(): void
     {
         $this->reportable(function (Throwable $e) {
             //

--- a/contents/app/Exceptions/Handler.php
+++ b/contents/app/Exceptions/Handler.php
@@ -10,15 +10,6 @@ use Throwable;
 class Handler extends ExceptionHandler
 {
     /**
-     * A list of the exception types that are not reported.
-     *
-     * @var array<int, class-string<Throwable>>
-     */
-    protected $dontReport = [
-        //
-    ];
-
-    /**
      * A list of the inputs that are never flashed for validation exceptions.
      *
      * @var array<int, string>

--- a/contents/app/Providers/AuthServiceProvider.php
+++ b/contents/app/Providers/AuthServiceProvider.php
@@ -20,7 +20,7 @@ class AuthServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         //
     }

--- a/contents/app/Providers/RouteServiceProvider.php
+++ b/contents/app/Providers/RouteServiceProvider.php
@@ -33,7 +33,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->configureRateLimiting();
 

--- a/contents/app/Providers/RouteServiceProvider.php
+++ b/contents/app/Providers/RouteServiceProvider.php
@@ -11,53 +11,30 @@ use Illuminate\Support\Facades\Route;
 class RouteServiceProvider extends ServiceProvider
 {
     /**
-     * The path to the "home" route for your application.
+     * The path to your application's "home" route.
      *
-     * This is used by Laravel authentication to redirect users after login.
+     * Typically, users are redirected here after authentication.
      *
      * @var string
      */
     public const HOME = '/home';
 
     /**
-     * The controller namespace for the application.
-     *
-     * When present, controller route declarations will automatically be prefixed with this namespace.
-     *
-     * @var string|null
-     */
-    // protected $namespace = 'App\\Http\\Controllers';
-
-    /**
-     * Define your route model bindings, pattern filters, etc.
-     *
-     * @return void
+     * Define your route model bindings, pattern filters, and other route configuration.
      */
     public function boot(): void
     {
-        $this->configureRateLimiting();
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+        });
 
         $this->routes(function () {
-            Route::prefix('api')
-                ->middleware('api')
-                ->namespace($this->namespace)
+            Route::middleware('api')
+                ->prefix('api')
                 ->group(base_path('routes/api.php'));
 
             Route::middleware('web')
-                ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));
-        });
-    }
-
-    /**
-     * Configure the rate limiters for the application.
-     *
-     * @return void
-     */
-    protected function configureRateLimiting()
-    {
-        RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });
     }
 }

--- a/contents/config/app.php
+++ b/contents/config/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\ServiceProvider;
 
 return [
 
@@ -129,6 +130,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Maintenance Mode Driver
+    |--------------------------------------------------------------------------
+    |
+    | These configuration options determine the driver used to determine and
+    | manage Laravel's "maintenance mode" status. The "cache" driver will
+    | allow maintenance mode to be controlled across multiple machines.
+    |
+    | Supported drivers: "file", "cache"
+    |
+    */
+
+    'maintenance' => [
+        'driver' => 'file',
+        // 'store'  => 'redis',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Autoloaded Service Providers
     |--------------------------------------------------------------------------
     |
@@ -138,35 +157,7 @@ return [
     |
     */
 
-    'providers' => [
-
-        /*
-         * Laravel Framework Service Providers...
-         */
-        Illuminate\Auth\AuthServiceProvider::class,
-        Illuminate\Broadcasting\BroadcastServiceProvider::class,
-        Illuminate\Bus\BusServiceProvider::class,
-        Illuminate\Cache\CacheServiceProvider::class,
-        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
-        Illuminate\Cookie\CookieServiceProvider::class,
-        Illuminate\Database\DatabaseServiceProvider::class,
-        Illuminate\Encryption\EncryptionServiceProvider::class,
-        Illuminate\Filesystem\FilesystemServiceProvider::class,
-        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
-        Illuminate\Hashing\HashServiceProvider::class,
-        Illuminate\Mail\MailServiceProvider::class,
-        Illuminate\Notifications\NotificationServiceProvider::class,
-        Illuminate\Pagination\PaginationServiceProvider::class,
-        Illuminate\Pipeline\PipelineServiceProvider::class,
-        Illuminate\Queue\QueueServiceProvider::class,
-        Illuminate\Redis\RedisServiceProvider::class,
-        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
-        Illuminate\Session\SessionServiceProvider::class,
-        Illuminate\Translation\TranslationServiceProvider::class,
-        Illuminate\Validation\ValidationServiceProvider::class,
-        Illuminate\View\ViewServiceProvider::class,
-        \L5Swagger\L5SwaggerServiceProvider::class,
-
+    'providers' => ServiceProvider::defaultProviders()->merge([
         /*
          * Package Service Providers...
          */
@@ -185,7 +176,8 @@ return [
         // Tymon\JWTAuth\Providers\LaravelServiceProvider::class, // remove package 
         CloudinaryLabs\CloudinaryLaravel\CloudinaryServiceProvider::class,
         Aws\Laravel\AwsServiceProvider::class,
-    ],
+        \L5Swagger\L5SwaggerServiceProvider::class,
+    ])->toArray(),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
### [[36] [Compare Code] Adds basic typing around method's arguments and return types](https://github.com/dtvn-training/linebot/pull/38/commits/9dc09e9b984255f8234f1cfdc53132565728328f)
- Adds basic typing around method's arguments and return types
=> Typing in php and laravel helps increase clarity, makes it easy to recognize what type of value the function returns, and is easy to maintain. If the return value and the typing around method have different data types, a warning may be generated (does not generate an error, making it easy for the developer to fix the error).

### [[36] [Compare Code] Remove unnecessary properties from exception handler](https://github.com/dtvn-training/linebot/pull/38/commits/bd238722789d8279f349b01de74c89338d526225)
- Remove unnecessary properties from exception handler ($levels and $dontReport)
+ `$levels` : Define logging levels for exceptions, with the following levels: PSR-3 (debug, info, notice, warning, error, critical, alert, emergency)
+ `$dontReport` : Defines exception types that are not written to the log file, making the log clean and compact"

### [[36] [Compare Code] Adding RateLimiter to the boot function is to simplify the code and Remove Namespace](https://github.com/dtvn-training/linebot/pull/38/commits/82895df04fd61797eb0e80b989c1384c75a23fa0)
- Adding RateLimiter to the boot function is to simplify the code
- Remove `->namespace($this->namespace)` because from laravel8 onwards there is auto-discovery"
### [[36] [Compare Code] Use default provider collection](https://github.com/dtvn-training/linebot/pull/38/commits/b31ab16bbdcecab010ba88951550173d953aa44d)
 - Use default provider collection
 - Instead of listing all Laravel framework Service Providers manually, now use the `ServiceProvider::defaultProviders()` method to get the default list of Service Providers.
