### PR TITLE
[36] [Compare Code] Fixes user factory unverified return and add variable password

### DIFF
--- a/contents/database/factories/UserFactory.php
+++ b/contents/database/factories/UserFactory.php
@@ -12,16 +12,21 @@ use Illuminate\Support\Facades\Hash;
 class UserFactory extends Factory
 {
     /**
+     * The current password being used by the factory.
+     */
+    protected static ?string $password;
+
+    /**
      * Define the model's default state.
      *
-     * @return array
+     * @return array<string, mixed>
      */
-    public function definition()
+    public function definition(): array
     {
         return [
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
-            'password' => Hash::make(random_bytes(6)),
+            'password' => static::$password ??= Hash::make('password'),
             'line_user_id' => bin2hex(random_bytes(16)),
             'is_delete' => 0,
             'is_block' => 0,
@@ -36,7 +41,7 @@ class UserFactory extends Factory
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */
-    public function unverified()
+    public function unverified(): static
     {
         return $this->state(function (array $attributes) {
             return [


### PR DESCRIPTION
### [[36] [Compare Code] Fixes user factory unverified return type and add protected static variable password](https://github.com/dtvn-training/linebot/pull/40/commits/eeb9c1f9180c3ead4dacd829f19ee20029507e53)
- Adds basic typing around method's arguments and return types
- Fixes user factory `unverified` return type
- Add protected static variable ?string $password
=> The password field is set to a fixed value or to the value in the static::$password variable. If $password has been previously set, it will not change. This can be useful when you want to create records with the same password, or to avoid hashing the password multiple times during data creation."