### PR TITLE
[36] [Compare Code] Add hashed cast to user password

### DIFF
--- a/contents/app/Models/Admin.php
+++ b/contents/app/Models/Admin.php
@@ -27,6 +27,7 @@ class Admin extends Authenticatable implements JWTSubject
 
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'password' => 'hashed', 
     ];
 
     public function getJWTIdentifier()

--- a/contents/app/Models/User.php
+++ b/contents/app/Models/User.php
@@ -42,6 +42,7 @@ class User extends Authenticatable implements JWTSubject
 
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'password' => 'hashed', 
     ];
 
     public function getJWTIdentifier()


### PR DESCRIPTION
### [[36] [Compare Code] Add hashed cast to user password](https://github.com/dtvn-training/linebot/pull/41/commits/f5c2703ceadb6a7d5dc4af4e7dc550e57e63603f)
- Add hashed cast to user password
=> Ensure the user's password is always hashed before saving to the database, regardless of whether it has been hashed or not, increasing security"