### PR TITLE
[36] [Compare Code] Add partitioned cookie config key

### DIFF
--- a/contents/config/session.php
+++ b/contents/config/session.php
@@ -198,4 +198,17 @@ return [
 
     'same_site' => 'lax',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Partitioned Cookies
+    |--------------------------------------------------------------------------
+    |
+    | Setting this value to true will tie the cookie to the top-level site for
+    | a cross-site context. Partitioned cookies are accepted by the browser
+    | when flagged "secure" and the Same-Site attribute is set to "none".
+    |
+    */
+
+    'partitioned' => false,
+
 ];


### PR DESCRIPTION
### [[36] [Compare Code] Add partitioned cookie config key](https://github.com/dtvn-training/linebot/pull/47/commits/8f9a3693db5dfc69fd795e9613f996bb46ee13cd)
- Add partitioned cookie config key 
=> Adding `'partitioned' => false` to the session configuration file in Laravel disables partitioning, causing all sessions to be stored collectively in a single session table instead of separated into separate session tables for each session. application or session. This can be useful when there is no need to partition sessions between applications or want to reduce the complexity of session management in the system. However, it should be noted that disabling partitioning may impact system performance and data structure, especially when a large number of sessions are used."