### PR TITLE
[36] [Compare Code] Disable pulse for testing

### DIFF
--- a/contents/phpunit.xml
+++ b/contents/phpunit.xml
@@ -15,6 +15,7 @@
     <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
     <!-- <env name="DB_DATABASE" value=":memory:"/> -->
     <env name="MAIL_MAILER" value="array"/>
+    <env name="PULSE_ENABLED" value="false"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="SESSION_DRIVER" value="array"/>
     <env name="TELESCOPE_ENABLED" value="false"/>


### PR DESCRIPTION
- Disable pulse for testing 
=> Laravel Pulse delivers at-a-glance insights into your application's performance and usage. With Pulse, you can track down bottlenecks like slow jobs and endpoints, find your most active users, and more.
=> Turning off Laravel Pulse if not in use can make the testing process faster."