### PR TITLE
[36] [Compare Code] Remove lodash

### DIFF
--- a/contents/package.json
+++ b/contents/package.json
@@ -12,7 +12,6 @@
     "devDependencies": {
         "axios": "^0.25",
         "laravel-mix": "^6.0.6",
-        "lodash": "^4.17.19",
         "postcss": "^8.1.14"
     }
 }


### PR DESCRIPTION
### [[36] [Compare Code] Remove lodash](https://github.com/dtvn-training/linebot/pull/49/commits/0e9797fcf119e8316c03b03e7182451087517b32)
- Laravel removes lodash library because it is not commonly used, unnecessary and makes the project heavier due to the need to download lodash for the project 
=> Linebot also does not use lodash library"