### PR TITLE
[36] [Compare Code] Adds basic typing around method's arguments and r…

### DIFF
--- a/contents/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/contents/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('password_resets', function (Blueprint $table) {
             $table->id();
@@ -28,7 +28,7 @@ return new class extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('password_resets');
     }


### PR DESCRIPTION
### [[36] [Compare Code] Adds basic typing around method's arguments and](https://github.com/dtvn-training/linebot/pull/51/commits/0a44604c428cc7d30787e086944d6d5f07eaa5b9)
- Adds basic typing around method's arguments and return types
- Proceed to rename the table from password_resets to password_reset_tokens.
=> There is nothing new in the code and does not affect the Lienbot project so there is no need to change."